### PR TITLE
Eliminate redundant code from remove()

### DIFF
--- a/src/skiplist.h
+++ b/src/skiplist.h
@@ -349,12 +349,7 @@ bool SKIPLIST_TYPE::remove(const KeyType key)
       bool marked = false;
       for (auto level = node_to_remove->top_level-1; level >= 1; --level)
       {
-        succ = node_to_remove->forward[level].get(marked);
-        while (!marked)
-        {
-          node_to_remove->forward[level].set_marked(true);
-          succ = node_to_remove->forward[level].get(marked);
-        }
+        node_to_remove->forward[level].set_marked(true);        
       }
 
       // bottom level


### PR DESCRIPTION
In remove() there was this fragment:
```
node_to_remove->forward[level].set_marked(true);
succ = node_to_remove->forward[level].get(marked);
```
which IMHO, isn't really doing much, because the compiler, and CPU are allowed to interpret the second line as reading the result of its own write from first line. Yes, there could be some other thread modifying the `node_to_remove->forward[level]`, but there's nothing which really forces our CPU to load such store - the store is permitted to "happen after" our load. Even if compiler doesn't eliminate it, a CPU might still handle `mov` by fetching data from its own store. And even if CPU doesn't, then still, there doesn't seem to be anything wrong in simply (us, developers) pretending that our load happens before any other stores here and eliminate this code ourselves.

We could still want to call `get(..)` to learn the new `succ` value resulting from our own `new` allocation inside `set_marked`, but we don't really use the `succ`'s value for anything in this code. Once we eliminate the second line by assuming it can simply read the `marked` value `true` we've stored ourselves, and that address of `succ` is not needed, then also the surrounding `while` loop can be eliminated.